### PR TITLE
Updated to Stylelint 8.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 module.exports = {
+  plugins: [
+    "stylelint-order"
+  ],
   rules: {
     // Color
     'color-hex-case': 'upper',
@@ -52,11 +55,9 @@ module.exports = {
     'declaration-bang-space-before': 'always',
     'declaration-colon-space-after': null,
     'declaration-colon-space-before': 'never',
-    // 'declaration-no-important': [true, {'severity': 'warning'}],
 
     // Declaration block
     'declaration-block-no-duplicate-properties': true,
-    'declaration-block-no-ignored-properties': [true, {'severity': 'warning'}],
     'declaration-block-no-shorthand-property-overrides': true,
     'declaration-block-semicolon-newline-after': 'always-multi-line',
     'declaration-block-semicolon-newline-before': 'never-multi-line',
@@ -64,7 +65,7 @@ module.exports = {
     'declaration-block-semicolon-space-before': 'never',
     'declaration-block-single-line-max-declarations': 1,
     'declaration-block-trailing-semicolon': 'always',
-    'declaration-block-properties-order': [
+    'order/properties-order': [
       [
         // Generated content
         'content',
@@ -209,7 +210,8 @@ module.exports = {
     'block-closing-brace-space-after': 'always-single-line',
     'block-closing-brace-space-before': 'always-single-line',
     'block-no-empty': null,
-    'block-no-single-line': true,
+    'block-opening-brace-newline-after': ['always'],
+    'block-closing-brace-newline-before': ['always'],
     'block-opening-brace-newline-after': 'always-multi-line',
     'block-opening-brace-newline-before': 'never-single-line',
     'block-opening-brace-space-after': 'always-single-line',
@@ -218,8 +220,8 @@ module.exports = {
     // Selector
     'selector-combinator-space-after': 'always',
     'selector-combinator-space-before': 'always',
-    // 'selector-no-id': [true, {'severity': 'warning'}],
-    'selector-no-universal': true,
+    'selector-max-id': 0,
+    'selector-max-universal': 0,
     'selector-no-vendor-prefix': [true, {'severity': 'warning'}],
     'selector-pseudo-class-case': 'lower',
     'selector-pseudo-class-no-unknown': true,
@@ -239,7 +241,6 @@ module.exports = {
     'media-feature-colon-space-after': 'always',
     'media-feature-colon-space-before': 'never',
     'media-feature-name-no-vendor-prefix': [true, {'severity': 'warning'}],
-    'media-feature-no-missing-punctuation': true,
     'media-feature-range-operator-space-after': 'always',
     'media-feature-range-operator-space-before': 'always',
     'media-feature-parentheses-space-inside': 'never',
@@ -249,7 +250,6 @@ module.exports = {
 
     // General / Sheet
     'max-empty-lines': 3,
-    // 'max-nesting-depth': [3, {'severity': 'warning'}],
     'no-descending-specificity': null,
     'no-eol-whitespace': true,
     'no-invalid-double-slash-comments': true,

--- a/index.js
+++ b/index.js
@@ -251,7 +251,6 @@ module.exports = {
     'comment-whitespace-inside': 'always',
 
     // General / Sheet
-    'indentation': 2,
     'max-empty-lines': 3,
     'no-descending-specificity': null,
     'no-eol-whitespace': true,

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
 
     // Font family
     'font-family-name-quotes': 'always-where-recommended',
+    'font-family-no-duplicate-names': true,
 
     // Function
     'function-calc-no-unspaced-operator': true,
@@ -59,6 +60,7 @@ module.exports = {
     // Declaration block
     'declaration-block-no-duplicate-properties': true,
     'declaration-block-no-shorthand-property-overrides': true,
+    'declaration-block-no-redundant-longhand-properties': true,
     'declaration-block-semicolon-newline-after': 'always-multi-line',
     'declaration-block-semicolon-newline-before': 'never-multi-line',
     'declaration-block-semicolon-space-after': 'always-single-line',
@@ -229,6 +231,7 @@ module.exports = {
     'selector-type-case': 'lower',
     'selector-type-no-unknown': [true, {'severity': 'warning'}],
     'selector-attribute-quotes': 'always',
+    'selector-descendant-combinator-no-non-space': true,
 
     // Selector list
     'selector-list-comma-newline-after': 'always',
@@ -248,6 +251,7 @@ module.exports = {
     'comment-whitespace-inside': 'always',
 
     // General / Sheet
+    'indentation': 2,
     'max-empty-lines': 3,
     'no-descending-specificity': null,
     'no-eol-whitespace': true,

--- a/index.js
+++ b/index.js
@@ -220,7 +220,6 @@ module.exports = {
     // Selector
     'selector-combinator-space-after': 'always',
     'selector-combinator-space-before': 'always',
-    'selector-max-id': 0,
     'selector-max-universal': 0,
     'selector-no-vendor-prefix': [true, {'severity': 'warning'}],
     'selector-pseudo-class-case': 'lower',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/wildbit/stylelint-config-wildbit#readme",
   "dependencies": {
-    "stylelint": "^8.0.0",
+    "stylelint": "~8.0.0",
     "stylelint-order": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-wildbit",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shareable stylelint config",
   "main": "index.js",
   "repository": {
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/wildbit/stylelint-config-wildbit#readme",
   "devDependencies": {
-    "stylelint": "^7.1.0"
+    "stylelint": "^8.0.0",
+    "stylelint-order": "^0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/wildbit/stylelint-config-wildbit/issues"
   },
   "homepage": "https://github.com/wildbit/stylelint-config-wildbit#readme",
-  "devDependencies": {
+  "dependencies": {
     "stylelint": "^8.0.0",
     "stylelint-order": "^0.6.0"
   }


### PR DESCRIPTION
I’ve updated the stylelint config to use version 8.0.0. We now need the [stylelint-order](https://github.com/hudochenkov/stylelint-order) plugin as the `declaration-block-properties-order` rule has been removed from core.